### PR TITLE
Deprecate Heap and fix incorrect UnsafePointer usage

### DIFF
--- a/Sources/WasmInterpreter/Heap.swift
+++ b/Sources/WasmInterpreter/Heap.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Heap will be removed in a later version")
 public struct Heap {
     public let pointer: UnsafeMutablePointer<UInt8>
     public let size: Int

--- a/Sources/WasmInterpreter/WasmInterpreter.swift
+++ b/Sources/WasmInterpreter/WasmInterpreter.swift
@@ -91,14 +91,11 @@ public final class WasmInterpreter {
         guard heap.isValid(offset: offset, length: length)
         else { throw WasmInterpreterError.invalidMemoryAccess }
 
-        return heap.pointer
+        let ptr = UnsafeRawPointer(heap.pointer)
             .advanced(by: offset)
-            .withMemoryRebound(
-                to: T.self,
-                capacity: length
-            ) { (pointer: UnsafeMutablePointer<T>) -> [T] in
-                return (0..<length).map { pointer.advanced(by: $0).pointee }
-            }
+            .bindMemory(to: T.self, capacity: length)
+
+        return (0..<length).map { ptr[$0] }
     }
 
     public func writeToHeap(data: Data, offset: Int) throws {

--- a/Sources/WasmInterpreter/WasmInterpreter.swift
+++ b/Sources/WasmInterpreter/WasmInterpreter.swift
@@ -50,6 +50,7 @@ public final class WasmInterpreter {
         removeImportedFunctions(for: _importedFunctionContexts)
     }
 
+    @available(*, deprecated, message: "Heap will be removed in a later version")
     public func heap() throws -> Heap {
         let totalBytes = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
         defer { totalBytes.deallocate() }

--- a/Sources/WasmInterpreter/WasmInterpreter.swift
+++ b/Sources/WasmInterpreter/WasmInterpreter.swift
@@ -55,9 +55,8 @@ public final class WasmInterpreter {
         let totalBytes = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
         defer { totalBytes.deallocate() }
 
-        guard let bytesPointer = m3_GetMemory(_runtime, totalBytes, 0) else {
-            throw WasmInterpreterError.invalidMemoryAccess
-        }
+        guard let bytesPointer = m3_GetMemory(_runtime, totalBytes, 0)
+        else { throw WasmInterpreterError.invalidMemoryAccess }
 
         return Heap(pointer: bytesPointer, size: Int(totalBytes.pointee))
     }
@@ -73,9 +72,10 @@ public final class WasmInterpreter {
 
     public func stringFromHeap(offset: Int, length: Int) throws -> String {
         let data = try dataFromHeap(offset: offset, length: length)
-        guard let string = String(data: data, encoding: .utf8) else {
-            throw WasmInterpreterError.invalidUTF8String
-        }
+
+        guard let string = String(data: data, encoding: .utf8)
+        else { throw WasmInterpreterError.invalidUTF8String }
+
         return string
     }
 


### PR DESCRIPTION
Besides deprecating the public interface of `Heap` in favor of the safer `writeToHeap()` and `dataFromHeap()` function, I also replaced a call of `UnsafePointer.withMemoryRebound()` with `UnsafeRawPointer.bindMemory()` because of this note in Apple's documentation:

> Only use `withMemoryRebound()` to rebind the pointer’s memory to a type with the same size and stride as the currently bound Pointee type. To bind a region of memory to a type that is a different size, convert the pointer to a raw pointer and use the bindMemory(to:capacity:) method.
>
> https://developer.apple.com/documentation/swift/unsafepointer/2430863-withmemoryrebound