### PR TITLE
Added 7 and 8 parameter native function and call

### DIFF
--- a/Sources/WasmInterpreter/NativeFunctionSignature.swift
+++ b/Sources/WasmInterpreter/NativeFunctionSignature.swift
@@ -225,6 +225,114 @@ func signature<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Ret>(
     return signature
 }
 
+func signature<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+    arg1: Arg1.Type,
+    arg2: Arg2.Type,
+    arg3: Arg3.Type,
+    arg4: Arg4.Type,
+    arg5: Arg5.Type,
+    arg6: Arg6.Type,
+    arg7: Arg7.Type
+) throws -> String
+    where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol, Arg4: WasmTypeProtocol,
+    Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol
+{
+    var signature = "v"
+    signature += "("
+    signature += try signatureIdentifier(for: arg1.self) + " "
+    signature += try signatureIdentifier(for: arg2.self) + " "
+    signature += try signatureIdentifier(for: arg3.self) + " "
+    signature += try signatureIdentifier(for: arg4.self) + " "
+    signature += try signatureIdentifier(for: arg5.self) + " "
+    signature += try signatureIdentifier(for: arg6.self) + " "
+    signature += try signatureIdentifier(for: arg7.self)
+    signature += ")"
+    return signature
+}
+
+func signature<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Ret>(
+    arg1: Arg1.Type,
+    arg2: Arg2.Type,
+    arg3: Arg3.Type,
+    arg4: Arg4.Type,
+    arg5: Arg5.Type,
+    arg6: Arg6.Type,
+    arg7: Arg7.Type,
+    ret: Ret.Type
+) throws -> String
+    where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol, Arg4: WasmTypeProtocol,
+    Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Ret: WasmTypeProtocol
+{
+    var signature = ""
+    signature += try signatureIdentifier(for: ret.self)
+    signature += "("
+    signature += try signatureIdentifier(for: arg1.self) + " "
+    signature += try signatureIdentifier(for: arg2.self) + " "
+    signature += try signatureIdentifier(for: arg3.self) + " "
+    signature += try signatureIdentifier(for: arg4.self) + " "
+    signature += try signatureIdentifier(for: arg5.self) + " "
+    signature += try signatureIdentifier(for: arg6.self) + " "
+    signature += try signatureIdentifier(for: arg7.self)
+    signature += ")"
+    return signature
+}
+
+func signature<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+    arg1: Arg1.Type,
+    arg2: Arg2.Type,
+    arg3: Arg3.Type,
+    arg4: Arg4.Type,
+    arg5: Arg5.Type,
+    arg6: Arg6.Type,
+    arg7: Arg7.Type,
+    arg8: Arg8.Type
+) throws -> String
+    where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol, Arg4: WasmTypeProtocol,
+    Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol
+{
+    var signature = "v"
+    signature += "("
+    signature += try signatureIdentifier(for: arg1.self) + " "
+    signature += try signatureIdentifier(for: arg2.self) + " "
+    signature += try signatureIdentifier(for: arg3.self) + " "
+    signature += try signatureIdentifier(for: arg4.self) + " "
+    signature += try signatureIdentifier(for: arg5.self) + " "
+    signature += try signatureIdentifier(for: arg6.self) + " "
+    signature += try signatureIdentifier(for: arg7.self) + " "
+    signature += try signatureIdentifier(for: arg8.self)
+    signature += ")"
+    return signature
+}
+
+func signature<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Ret>(
+    arg1: Arg1.Type,
+    arg2: Arg2.Type,
+    arg3: Arg3.Type,
+    arg4: Arg4.Type,
+    arg5: Arg5.Type,
+    arg6: Arg6.Type,
+    arg7: Arg7.Type,
+    arg8: Arg8.Type,
+    ret: Ret.Type
+) throws -> String
+    where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol, Arg4: WasmTypeProtocol,
+    Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol, Ret: WasmTypeProtocol
+{
+    var signature = ""
+    signature += try signatureIdentifier(for: ret.self)
+    signature += "("
+    signature += try signatureIdentifier(for: arg1.self) + " "
+    signature += try signatureIdentifier(for: arg2.self) + " "
+    signature += try signatureIdentifier(for: arg3.self) + " "
+    signature += try signatureIdentifier(for: arg4.self) + " "
+    signature += try signatureIdentifier(for: arg5.self) + " "
+    signature += try signatureIdentifier(for: arg6.self) + " "
+    signature += try signatureIdentifier(for: arg7.self) + " "
+    signature += try signatureIdentifier(for: arg8.self)
+    signature += ")"
+    return signature
+}
+
 func signatureIdentifier<T: WasmTypeProtocol>(for type: T.Type) throws -> String {
     if Int32.self == T.self { return "i" }
     else if Int64.self == T.self { return "I" }

--- a/Sources/WasmInterpreter/WasmInterpreter+Call.swift
+++ b/Sources/WasmInterpreter/WasmInterpreter+Call.swift
@@ -128,4 +128,68 @@ extension WasmInterpreter {
                    try String(wasmType: arg4), try String(wasmType: arg5), try String(wasmType: arg6)]
         )
     }
+    
+    public func call<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        _ name: String, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3,
+        _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
+    ) throws
+      where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+            Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol,
+            Arg7: WasmTypeProtocol
+    {
+        try _call(
+            try function(named: name),
+            args: [try String(wasmType: arg1), try String(wasmType: arg2), try String(wasmType: arg3),
+                   try String(wasmType: arg4), try String(wasmType: arg5), try String(wasmType: arg6),
+                   try String(wasmType: arg7)]
+        )
+    }
+    
+    public func call<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Ret>(
+        _ name: String, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3,
+        _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7
+    ) throws -> Ret
+      where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+            Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol,
+            Arg7: WasmTypeProtocol, Ret: WasmTypeProtocol
+    {
+        return try _call(
+            try function(named: name),
+            args: [try String(wasmType: arg1), try String(wasmType: arg2), try String(wasmType: arg3),
+                   try String(wasmType: arg4), try String(wasmType: arg5), try String(wasmType: arg6),
+                   try String(wasmType: arg7)]
+        )
+    }
+    
+    public func call<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        _ name: String, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3,
+        _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
+    ) throws
+      where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+            Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol,
+            Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol
+    {
+        try _call(
+            try function(named: name),
+            args: [try String(wasmType: arg1), try String(wasmType: arg2), try String(wasmType: arg3),
+                   try String(wasmType: arg4), try String(wasmType: arg5), try String(wasmType: arg6),
+                   try String(wasmType: arg7), try String(wasmType: arg8)]
+        )
+    }
+    
+    public func call<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Ret>(
+        _ name: String, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3,
+        _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7, _ arg8: Arg8
+    ) throws -> Ret
+      where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+            Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol,
+            Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol, Ret: WasmTypeProtocol
+    {
+        return try _call(
+            try function(named: name),
+            args: [try String(wasmType: arg1), try String(wasmType: arg2), try String(wasmType: arg3),
+                   try String(wasmType: arg4), try String(wasmType: arg5), try String(wasmType: arg6),
+                   try String(wasmType: arg7), try String(wasmType: arg8)]
+        )
+    }
 }

--- a/Sources/WasmInterpreter/WasmInterpreter+ImportHandler.swift
+++ b/Sources/WasmInterpreter/WasmInterpreter+ImportHandler.swift
@@ -704,13 +704,13 @@ extension WasmInterpreter {
         try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
     }
     
-    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Ret>(
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
         named name: String,
         namespace: String,
-        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) throws -> Ret
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) throws -> Void
     ) throws
         where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
-              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Ret: WasmTypeProtocol
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol
     {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
@@ -722,6 +722,68 @@ extension WasmInterpreter {
                 let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
                 let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
                 let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self,
+            arg4: Arg4.self, arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
+
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, UnsafeMutableRawPointer?) throws -> Void
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, heap)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self,
+            arg4: Arg4.self, arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
+    
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Ret>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) throws -> Ret
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Ret: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 6)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 7)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -747,13 +809,13 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
-                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
-                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
-                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 6)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 7)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -764,6 +826,70 @@ extension WasmInterpreter {
         let sig = try signature(
             arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self, arg4: Arg4.self,
             arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self, ret: Ret.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
+    
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) throws -> Void
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 7)
+                try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self,
+            arg4: Arg4.self, arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self, arg8: Arg8.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
+
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, UnsafeMutableRawPointer?) throws -> Void
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 7)
+                try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, heap)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self,
+            arg4: Arg4.self, arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self, arg8: Arg8.self
         )
         try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
     }
@@ -779,14 +905,14 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
-                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
-                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
-                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
-                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 7)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 6)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 7)
+                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 8)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -812,14 +938,14 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
-                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
-                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
-                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
-                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 7)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 6)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 7)
+                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 8)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil

--- a/Sources/WasmInterpreter/WasmInterpreter+ImportHandler.swift
+++ b/Sources/WasmInterpreter/WasmInterpreter+ImportHandler.swift
@@ -703,4 +703,134 @@ extension WasmInterpreter {
         )
         try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
     }
+    
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Ret>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) throws -> Ret
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Ret: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+                try NativeFunction.pushReturnValue(ret, to: stack)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self, arg4: Arg4.self,
+            arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self, ret: Ret.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
+    
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Ret>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, UnsafeMutableRawPointer?) throws -> Ret
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Ret: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, heap)
+                try NativeFunction.pushReturnValue(ret, to: stack)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self, arg4: Arg4.self,
+            arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self, ret: Ret.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
+    
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Ret>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) throws -> Ret
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol, Ret: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 7)
+                let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+                try NativeFunction.pushReturnValue(ret, to: stack)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self, arg4: Arg4.self,
+            arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self, arg8: Arg8.self, ret: Ret.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
+    
+    public func addImportHandler<Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Ret>(
+        named name: String,
+        namespace: String,
+        block: @escaping (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, UnsafeMutableRawPointer?) throws -> Ret
+    ) throws
+        where Arg1: WasmTypeProtocol, Arg2: WasmTypeProtocol, Arg3: WasmTypeProtocol,
+              Arg4: WasmTypeProtocol, Arg5: WasmTypeProtocol, Arg6: WasmTypeProtocol, Arg7: WasmTypeProtocol, Arg8: WasmTypeProtocol, Ret: WasmTypeProtocol
+    {
+        let importedFunction: ImportedFunctionSignature =
+        { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
+            do {
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg7: Arg7 = try NativeFunction.argument(from: stack, at: 6)
+                let arg8: Arg8 = try NativeFunction.argument(from: stack, at: 7)
+                let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, heap)
+                try NativeFunction.pushReturnValue(ret, to: stack)
+                return nil
+            } catch {
+                return importedFunctionInternalError
+            }
+        }
+        let sig = try signature(
+            arg1: Arg1.self, arg2: Arg2.self, arg3: Arg3.self, arg4: Arg4.self,
+            arg5: Arg5.self, arg6: Arg6.self, arg7: Arg7.self, arg8: Arg8.self, ret: Ret.self
+        )
+        try self.importNativeFunction(named: name, namespace: namespace, signature: sig, handler: importedFunction)
+    }
 }


### PR DESCRIPTION
Hey 👋🏻 

First of all, thank you for this awesome project! It has been great to implement bi-directional procedure calls between a swift host and a wasm guest. We have a standardized spec called `waPC`, and one of our functions requires an 8 parameter function call (see https://docs.rs/wapc/0.10.1/wapc/#required-host-exports for `__host_call`). 

I tested this out first by forking this and using a local package in my swift project, and it worked great, this really only extends what you all have already put together with 7 and 8 parameters.