### PR TITLE
Update CWasm3 to v0.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/shareup/cwasm3.git",
         "state": {
           "branch": null,
-          "revision": "da60d7f032fd5be33053d51eb0d855b95ea163f1",
-          "version": "0.4.10"
+          "revision": "1e7c4db769e0638d3c0833a941ffb475100a5c0d",
+          "version": "0.5.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(
             name: "CWasm3",
             url: "https://github.com/shareup/cwasm3.git",
-            from: "0.4.10"),
+            from: "0.5.0"),
         .package(
             name: "Synchronized",
             url: "https://github.com/shareup/synchronized.git",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use `WasmInterpreter` with the Swift Package Manager, add a dependency to you
 
 ```swift
 dependencies: [
-  .package(name: "WasmInterpreter", url: "https://github.com/shareup/wasm-interpreter-apple.git", from: "0.5.0"),
+  .package(name: "WasmInterpreter", url: "https://github.com/shareup/wasm-interpreter-apple.git", from: "0.5.1"),
 ],
 ```
 

--- a/Sources/WasmInterpreter/WasmInterpreter+ImportHandler.swift
+++ b/Sources/WasmInterpreter/WasmInterpreter+ImportHandler.swift
@@ -1,6 +1,16 @@
 import Foundation
 import CWasm3
 
+// Arguments and return values are passed in and out through the stack pointer
+// of imported functions.
+//
+// Placeholder return value slots are first and arguments after. So, the first
+// argument is at _sp [numReturns].
+//
+// Return values should be written into _sp [0] to _sp [num_returns - 1].
+//
+// Wasm3 always aligns the stack to 64 bits.
+
 extension WasmInterpreter {
     public func addImportHandler(
         named name: String,
@@ -152,7 +162,7 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
                 let ret = try block(arg1)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -177,7 +187,7 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
                 let ret = try block(arg1, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -242,8 +252,8 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
                 let ret = try block(arg1, arg2)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -263,8 +273,8 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
                 let ret = try block(arg1, arg2, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -326,9 +336,9 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
                 let ret = try block(arg1, arg2, arg3)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -348,9 +358,9 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
                 let ret = try block(arg1, arg2, arg3, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -421,10 +431,10 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
                 let ret = try block(arg1, arg2, arg3, arg4)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -447,10 +457,10 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
                 let ret = try block(arg1, arg2, arg3, arg4, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -525,11 +535,11 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
-                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -554,11 +564,11 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
-                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -643,12 +653,12 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
-                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
-                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 6)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil
@@ -674,12 +684,12 @@ extension WasmInterpreter {
         let importedFunction: ImportedFunctionSignature =
         { (stack: UnsafeMutablePointer<UInt64>?, heap: UnsafeMutableRawPointer?) -> UnsafeRawPointer? in
             do {
-                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 0)
-                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 1)
-                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 2)
-                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 3)
-                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 4)
-                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 5)
+                let arg1: Arg1 = try NativeFunction.argument(from: stack, at: 1)
+                let arg2: Arg2 = try NativeFunction.argument(from: stack, at: 2)
+                let arg3: Arg3 = try NativeFunction.argument(from: stack, at: 3)
+                let arg4: Arg4 = try NativeFunction.argument(from: stack, at: 4)
+                let arg5: Arg5 = try NativeFunction.argument(from: stack, at: 5)
+                let arg6: Arg6 = try NativeFunction.argument(from: stack, at: 6)
                 let ret = try block(arg1, arg2, arg3, arg4, arg5, arg6, heap)
                 try NativeFunction.pushReturnValue(ret, to: stack)
                 return nil


### PR DESCRIPTION
CWasm3 corresponds to [Wasm3 v0.5.0](https://github.com/wasm3/wasm3/releases/tag/v0.5.0).

The one change that affected us was the change of where imported function arguments are placed on the stack. With v0.5.0, arguments are placed after the return values. Previously, the arguments would be placed at the top of the stack, and they'd be overwritten by the return value from the imported function.